### PR TITLE
Rename project to twig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,15 +395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
-name = "mcpkg"
-version = "0.1.0"
-dependencies = [
- "clap",
- "rmcp",
- "tokio",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +796,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "twig"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "rmcp",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mcpkg"
+name = "twig"
 version = "0.1.0"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# mcpkg
+# twig
 
-The model context package manager
+Help your coding agent twig.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -24,7 +24,7 @@ impl ServerHandler for Server {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
             server_info: Implementation {
-                name: "mcpkg".to_string(),
+                name: "twig".to_string(),
                 version: "dev".to_string(),
                 icons: None,
                 website_url: None,


### PR DESCRIPTION
This name is less restrictive and technical than mcpkg. Instead it gives me the flexibility to build the features I want to build.